### PR TITLE
Implement UploadCompetitionRankingScore for Splatfest

### DIFF
--- a/competition_ranking_scores.sql
+++ b/competition_ranking_scores.sql
@@ -1,9 +1,9 @@
 CREATE TABLE IF NOT EXISTS competition_ranking_scores (
     id bigserial PRIMARY KEY,
     pid numeric(10) NOT NULL,
-    festival_id integer NOT NULL,
-    score integer NOT NULL,
+    festival_id bigint NOT NULL,
+    score bigint NOT NULL,
     team_id smallint NOT NULL,
-    team_score integer NOT NULL,
+    team_score bigint NOT NULL,
     is_first_upload boolean NOT NULL
 );

--- a/competition_ranking_scores.sql
+++ b/competition_ranking_scores.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS competition_ranking_scores (
+    id bigserial PRIMARY KEY,
+    pid numeric(10) NOT NULL,
+    festival_id integer NOT NULL,
+    score integer NOT NULL,
+    team_id smallint NOT NULL,
+    team_score integer NOT NULL,
+    is_first_upload boolean NOT NULL
+);

--- a/globals/upload_competition_ranking_score.go
+++ b/globals/upload_competition_ranking_score.go
@@ -1,6 +1,7 @@
 package globals
 
 import (
+	"fmt"
 	nex "github.com/PretendoNetwork/nex-go/v2"
 	ranking "github.com/PretendoNetwork/nex-protocols-go/v2/ranking/splatoon"
 )
@@ -18,27 +19,27 @@ func UploadCompetitionRankingScore(err error, packet nex.PacketInterface, callID
 	// Read CompetitionRankingUploadScoreParam data
 	festivalID, streamErr := parametersStream.ReadUInt32LE()
 	if streamErr != nil {
-		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read festival_id")
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, fmt.Sprintf("Failed to read festival_id: %v", streamErr))
 	}
 
 	score, streamErr := parametersStream.ReadUInt32LE()
 	if streamErr != nil {
-		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read score")
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, fmt.Sprintf("Failed to read score: %v", streamErr))
 	}
 
 	teamID, streamErr := parametersStream.ReadUInt8()
 	if streamErr != nil {
-		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read team_id")
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, fmt.Sprintf("Failed to read team_id: %v", streamErr))
 	}
 
 	teamScore, streamErr := parametersStream.ReadUInt32LE()
 	if streamErr != nil {
-		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read team_score")
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, fmt.Sprintf("Failed to read team_score: %v", streamErr))
 	}
 
 	isFirstUpload, streamErr := parametersStream.ReadBool()
 	if streamErr != nil {
-		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read is_first_upload")
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, fmt.Sprintf("Failed to read is_first_upload: %v", streamErr))
 	}
 
 	pid := packet.Sender().PID()

--- a/globals/upload_competition_ranking_score.go
+++ b/globals/upload_competition_ranking_score.go
@@ -1,0 +1,61 @@
+package globals
+
+import (
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	ranking "github.com/PretendoNetwork/nex-protocols-go/v2/ranking/splatoon"
+)
+
+func UploadCompetitionRankingScore(err error, packet nex.PacketInterface, callID uint32, packetPayload []byte) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	request := packet.RMCMessage()
+	parameters := request.Parameters
+	endpoint := packet.Sender().Endpoint()
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	// Read CompetitionRankingUploadScoreParam data
+	festivalID, streamErr := parametersStream.ReadUInt32LE()
+	if streamErr != nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read festival_id")
+	}
+
+	score, streamErr := parametersStream.ReadUInt32LE()
+	if streamErr != nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read score")
+	}
+
+	teamID, streamErr := parametersStream.ReadUInt8()
+	if streamErr != nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read team_id")
+	}
+
+	teamScore, streamErr := parametersStream.ReadUInt32LE()
+	if streamErr != nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read team_score")
+	}
+
+	isFirstUpload, streamErr := parametersStream.ReadBool()
+	if streamErr != nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read is_first_upload")
+	}
+
+	pid := packet.Sender().PID()
+
+	_, dbErr := Postgres.Exec(
+		"INSERT INTO competition_ranking_scores (pid, festival_id, score, team_id, team_score, is_first_upload) VALUES ($1, $2, $3, $4, $5, $6)",
+		pid, festivalID, score, teamID, teamScore, isFirstUpload,
+	)
+	if dbErr != nil {
+		Logger.Error(dbErr.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Database error")
+	}
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, nil)
+	rmcResponse.ProtocolID = ranking.ProtocolID
+	rmcResponse.MethodID = ranking.MethodUploadCompetitionRankingScore
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/nex/register_common_secure_server_protocols.go
+++ b/nex/register_common_secure_server_protocols.go
@@ -56,6 +56,7 @@ func registerCommonSecureServerProtocols() {
 	commonMatchmakeExtensionProtocol.SetManager(globals.MatchmakingManager)
 
 	rankingProtocol := ranking.NewProtocol(globals.SecureEndpoint)
+	rankingProtocol.UploadCompetitionRankingScore = globals.UploadCompetitionRankingScore
 	globals.SecureEndpoint.RegisterServiceProtocol(rankingProtocol)
 	commonranking.NewCommonProtocol(rankingProtocol)
 }


### PR DESCRIPTION
Finally got around to finishing the Splatfest implementation. The method was completely stubbed out so I added the handler to actually save competition ranking scores to the database.

Basically what I did:
- Created the handler that reads the CompetitionRankingUploadScoreParam from the packet and extracts festival_id, score, team_id, team_score, is_first_upload
- Added the competition_ranking_scores table to store the results
- Wired it up in the protocol registration

Splatfest should now actually work instead of just silently dropping all the score data. Haven't tested it on actual Wii U yet but the server compiles and the handler logic looks solid.

<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #6

### Changes:

- Added `UploadCompetitionRankingScore` handler in `globals/upload_competition_ranking_score.go` that parses the NEX packet and extracts competition ranking data
- Created PostgreSQL migration `competition_ranking_scores.sql` with schema for storing festival_id, score, team_id, team_score, is_first_upload
- Integrated handler into ranking protocol via `register_common_secure_server_protocols.go`

Database migration:
```sql
CREATE TABLE IF NOT EXISTS competition_ranking_scores (
    id bigserial PRIMARY KEY,
    pid numeric(10) NOT NULL,
    festival_id integer NOT NULL,
    score integer NOT NULL,
    team_id smallint NOT NULL,
    team_score integer NOT NULL,
    is_first_upload boolean NOT NULL
);
```

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.