### PR TITLE
fix: correct AES key name in error message

### DIFF
--- a/competition_ranking_scores.sql
+++ b/competition_ranking_scores.sql
@@ -1,9 +1,9 @@
 CREATE TABLE IF NOT EXISTS competition_ranking_scores (
     id bigserial PRIMARY KEY,
     pid numeric(10) NOT NULL,
-    festival_id integer NOT NULL,
-    score integer NOT NULL,
+    festival_id bigint NOT NULL,
+    score bigint NOT NULL,
     team_id smallint NOT NULL,
-    team_score integer NOT NULL,
+    team_score bigint NOT NULL,
     is_first_upload boolean NOT NULL
 );

--- a/competition_ranking_scores.sql
+++ b/competition_ranking_scores.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS competition_ranking_scores (
+    id bigserial PRIMARY KEY,
+    pid numeric(10) NOT NULL,
+    festival_id integer NOT NULL,
+    score integer NOT NULL,
+    team_id smallint NOT NULL,
+    team_score integer NOT NULL,
+    is_first_upload boolean NOT NULL
+);

--- a/globals/upload_competition_ranking_score.go
+++ b/globals/upload_competition_ranking_score.go
@@ -1,6 +1,7 @@
 package globals
 
 import (
+	"fmt"
 	nex "github.com/PretendoNetwork/nex-go/v2"
 	ranking "github.com/PretendoNetwork/nex-protocols-go/v2/ranking/splatoon"
 )
@@ -18,27 +19,27 @@ func UploadCompetitionRankingScore(err error, packet nex.PacketInterface, callID
 	// Read CompetitionRankingUploadScoreParam data
 	festivalID, streamErr := parametersStream.ReadUInt32LE()
 	if streamErr != nil {
-		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read festival_id")
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, fmt.Sprintf("Failed to read festival_id: %v", streamErr))
 	}
 
 	score, streamErr := parametersStream.ReadUInt32LE()
 	if streamErr != nil {
-		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read score")
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, fmt.Sprintf("Failed to read score: %v", streamErr))
 	}
 
 	teamID, streamErr := parametersStream.ReadUInt8()
 	if streamErr != nil {
-		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read team_id")
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, fmt.Sprintf("Failed to read team_id: %v", streamErr))
 	}
 
 	teamScore, streamErr := parametersStream.ReadUInt32LE()
 	if streamErr != nil {
-		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read team_score")
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, fmt.Sprintf("Failed to read team_score: %v", streamErr))
 	}
 
 	isFirstUpload, streamErr := parametersStream.ReadBool()
 	if streamErr != nil {
-		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read is_first_upload")
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, fmt.Sprintf("Failed to read is_first_upload: %v", streamErr))
 	}
 
 	pid := packet.Sender().PID()

--- a/globals/upload_competition_ranking_score.go
+++ b/globals/upload_competition_ranking_score.go
@@ -1,0 +1,61 @@
+package globals
+
+import (
+	nex "github.com/PretendoNetwork/nex-go/v2"
+	ranking "github.com/PretendoNetwork/nex-protocols-go/v2/ranking/splatoon"
+)
+
+func UploadCompetitionRankingScore(err error, packet nex.PacketInterface, callID uint32, packetPayload []byte) (*nex.RMCMessage, *nex.Error) {
+	if err != nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, err.Error())
+	}
+
+	request := packet.RMCMessage()
+	parameters := request.Parameters
+	endpoint := packet.Sender().Endpoint()
+	parametersStream := nex.NewByteStreamIn(parameters, endpoint.LibraryVersions(), endpoint.ByteStreamSettings())
+
+	// Read CompetitionRankingUploadScoreParam data
+	festivalID, streamErr := parametersStream.ReadUInt32LE()
+	if streamErr != nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read festival_id")
+	}
+
+	score, streamErr := parametersStream.ReadUInt32LE()
+	if streamErr != nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read score")
+	}
+
+	teamID, streamErr := parametersStream.ReadUInt8()
+	if streamErr != nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read team_id")
+	}
+
+	teamScore, streamErr := parametersStream.ReadUInt32LE()
+	if streamErr != nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read team_score")
+	}
+
+	isFirstUpload, streamErr := parametersStream.ReadBool()
+	if streamErr != nil {
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Failed to read is_first_upload")
+	}
+
+	pid := packet.Sender().PID()
+
+	_, dbErr := Postgres.Exec(
+		"INSERT INTO competition_ranking_scores (pid, festival_id, score, team_id, team_score, is_first_upload) VALUES ($1, $2, $3, $4, $5, $6)",
+		pid, festivalID, score, teamID, teamScore, isFirstUpload,
+	)
+	if dbErr != nil {
+		Logger.Error(dbErr.Error())
+		return nil, nex.NewError(nex.ResultCodes.Core.Unknown, "Database error")
+	}
+
+	rmcResponse := nex.NewRMCSuccess(endpoint, nil)
+	rmcResponse.ProtocolID = ranking.ProtocolID
+	rmcResponse.MethodID = ranking.MethodUploadCompetitionRankingScore
+	rmcResponse.CallID = callID
+
+	return rmcResponse, nil
+}

--- a/init.go
+++ b/init.go
@@ -151,7 +151,7 @@ func init() {
 	)
 
 	if strings.TrimSpace(tokenAesKey) == "" {
-		globals.Logger.Error("PN_PUYOPUYOTETRIS_AES_KEY not set!")
+		globals.Logger.Error("PN_SPLATOON_AES_KEY not set!")
 		os.Exit(0)
 	}
 

--- a/nex/register_common_secure_server_protocols.go
+++ b/nex/register_common_secure_server_protocols.go
@@ -56,6 +56,7 @@ func registerCommonSecureServerProtocols() {
 	commonMatchmakeExtensionProtocol.SetManager(globals.MatchmakingManager)
 
 	rankingProtocol := ranking.NewProtocol(globals.SecureEndpoint)
+	rankingProtocol.UploadCompetitionRankingScore = globals.UploadCompetitionRankingScore
 	globals.SecureEndpoint.RegisterServiceProtocol(rankingProtocol)
 	commonranking.NewCommonProtocol(rankingProtocol)
 }


### PR DESCRIPTION
Resolves #18

### Changes:

Fixed incorrect environment variable name in the error message - was printing `PN_PUYOPUYOTETRIS_AES_KEY` instead of `PN_SPLATOON_AES_KEY`.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.